### PR TITLE
Benchmark 18

### DIFF
--- a/benchmark_base.py
+++ b/benchmark_base.py
@@ -1,0 +1,36 @@
+import statistics
+
+from datetime import datetime
+
+
+class Benchmark(object):
+    def __init__(self, n_runs: int=5, print_checkpoint: bool=True):
+        self.n_runs = n_runs
+        self.print_checkpoint = print_checkpoint
+
+    def log(self, message: str) -> None:
+        print('[%s] - %s' % (datetime.now(), message))
+
+    def log_stats(self, times: list, unit: str='ms'):
+        self.log('[iteration %s/%s] %s' % (len(times), self.n_runs, self.format_stats(times, unit=unit)))
+
+    def format_stats(self, times: list, unit: str) -> str:
+        return 'median: %.2f%s, mean: %.2f%s, stdev: %.2f, max: %.2f%s, min: %.2f%s' % (
+            statistics.median(times), unit,
+            statistics.mean(times), unit,
+            statistics.stdev(times),
+            max(times), unit,
+            min(times), unit
+        )
+
+    def start(self, suffix: str=None):
+        if suffix is None:
+            suffix = '...'
+        else:
+            suffix = ': ' + suffix
+
+        self.log('starting benchmark%s' % suffix)
+        self.benchmark()
+
+    def benchmark(self):
+        raise NotImplementedError('method benchmark() not implemented yet')

--- a/benchmark_concordance.py
+++ b/benchmark_concordance.py
@@ -1,6 +1,5 @@
 import tempfile
 import bz2
-import statistics
 import os
 import time
 
@@ -11,6 +10,7 @@ import random
 
 from multiprocessing import Pool
 
+from benchmark_base import Benchmark
 from concordance import get_competition_variables_from_df
 from concordance import has_concordance
 from concordance import get_sorted_split
@@ -19,95 +19,93 @@ N_SAMPLES = 100 * 1000
 N_RUNS = 250
 
 
-def load_data():
-    data_frames = dict()
-    for sample_type, sample_file in [
-        ('train', 'data/sample_training.csv.bz2'),
-        ('predict', 'data/sample_tournament.csv.bz2'),
-        ('result', 'data/sample_result.csv.bz2')
-    ]:
-        with tempfile.NamedTemporaryFile() as temp_file, \
-                open(temp_file.name, 'wb') as uncompressed_file, \
-                bz2.BZ2File(sample_file, 'rb') as compressed_file:
+class BenchmarkConcordance(Benchmark):
+    def load_data(self):
+        data_frames = dict()
+        for sample_type, sample_file in [
+            ('train', 'data/sample_training.csv.bz2'),
+            ('predict', 'data/sample_tournament.csv.bz2'),
+            ('result', 'data/sample_result.csv.bz2')
+        ]:
+            with tempfile.NamedTemporaryFile() as temp_file, \
+                    open(temp_file.name, 'wb') as uncompressed_file, \
+                    bz2.BZ2File(sample_file, 'rb') as compressed_file:
 
-            for data in iter(lambda: compressed_file.read(1000 * 1024), b''):
-                uncompressed_file.write(data)
-            data_frames[sample_type] = pd.read_csv(temp_file)
-    return data_frames['train'], data_frames['predict'], data_frames['result']
+                for data in iter(lambda: compressed_file.read(1000 * 1024), b''):
+                    uncompressed_file.write(data)
+                data_frames[sample_type] = pd.read_csv(temp_file)
+        return data_frames['train'], data_frames['predict'], data_frames['result']
 
+    def gen_more_data(self, train: pd.DataFrame, predict: pd.DataFrame, result: pd.DataFrame):
+        new_train = self.gen_similar_df(train, data_types=['train'])
+        new_predict = self.gen_similar_df(predict, data_types=['live', 'validation', 'test'])
 
-def gen_more_data(train: pd.DataFrame, predict: pd.DataFrame, result: pd.DataFrame):
-    new_train = gen_similar_df(train, data_types=['train'])
-    new_predict = gen_similar_df(predict, data_types=['live', 'validation', 'test'])
+        sample = result.sample(len(new_predict), replace=True).probability.copy().values.ravel()
+        new_result = pd.DataFrame.from_dict({
+            'id': new_predict.id.copy(),
+            'probability': sample + rnd.normal(loc=0.0, scale=0.025, size=(len(new_predict),))
+        })
+        return new_train, new_predict, new_result
 
-    sample = result.sample(len(new_predict), replace=True).probability.copy().values.ravel()
-    new_result = pd.DataFrame.from_dict({
-        'id': new_predict.id.copy(),
-        'probability': sample + rnd.normal(loc=0.0, scale=0.025, size=(len(new_predict),))
-    })
-    return new_train, new_predict, new_result
+    def gen_similar_df(self, df: pd.DataFrame, data_types: list) -> pd.DataFrame:
+        sample_batch_size = 500
+        new_df = pd.DataFrame(data=None, columns=df.columns)
+        features = [col for col in df.columns if 'feature' in col]
 
+        for batch_nr in range(N_SAMPLES // sample_batch_size):
+            sample = df.sample(sample_batch_size, replace=True)
+            sample = sample[features] + rnd.normal(loc=0.0, scale=0.1, size=sample[features].shape)
+            sample = sample.as_matrix()
+            new_ids = np.array([batch_nr*sample_batch_size + j for j in range(sample_batch_size)])
 
-def gen_similar_df(df: pd.DataFrame, data_types: list) -> pd.DataFrame:
-    sample_batch_size = 500
-    new_df = pd.DataFrame(data=None, columns=df.columns)
-    features = [col for col in df.columns if 'feature' in col]
+            data_types = [random.choice(data_types) for _ in range(sample_batch_size)]
+            new_batch = {
+                'id': new_ids,
+                'era': ['era%s' % random.choice([i+1 for i in range(99)]) for _ in range(sample_batch_size)],
+                'data_type': data_types,
+                'target': [random.choice([0, 1]) if data_types[i] != 'live' else np.nan for i in range(sample_batch_size)]
+            }
 
-    for batch_nr in range(N_SAMPLES // sample_batch_size):
-        sample = df.sample(sample_batch_size, replace=True)
-        sample = sample[features] + rnd.normal(loc=0.0, scale=0.1, size=sample[features].shape)
-        sample = sample.as_matrix()
-        new_ids = np.array([batch_nr*sample_batch_size + j for j in range(sample_batch_size)])
+            for f_num, feature in enumerate(features):
+                new_batch[feature] = sample[:, f_num]
+            new_df = pd.concat((new_df, pd.DataFrame.from_dict(new_batch)), axis=0)
+        return new_df
 
-        data_types = [random.choice(data_types) for _ in range(sample_batch_size)]
-        new_batch = {
-            'id': new_ids,
-            'era': ['era%s' % random.choice([i+1 for i in range(99)]) for _ in range(sample_batch_size)],
-            'data_type': data_types,
-            'target': [random.choice([0, 1]) if data_types[i] != 'live' else np.nan for i in range(sample_batch_size)]
+    def check_concordance(self, submission, clusters, ids):
+        t0 = time.time()
+        ids_valid, ids_test, ids_live = ids['valid'], ids['test'], ids['live']
+        p1, p2, p3 = get_sorted_split(submission, ids_valid, ids_test, ids_live)
+        c1, c2, c3 = clusters['cluster_1'], clusters['cluster_2'], clusters['cluster_3']
+        has_concordance(p1, p2, p3, c1, c2, c3)
+        t1 = time.time()
+        return (t1 - t0) * 1000
+
+    def benchmark(self):
+        # try to use half the available cores to avoid shaky medians per run caused by cpu usage from other processes
+        pool_size = os.cpu_count() or 1
+        if pool_size > 1:
+            pool_size = pool_size//2
+
+        source_train_data, source_predict_data, source_submission = self.load_data()
+        train_data, predict_data, submission_data = \
+            self.gen_more_data(source_train_data, source_predict_data, source_submission)
+
+        ids = {
+            'test': predict_data[predict_data.data_type == 'test'].id.copy().values.ravel(),
+            'valid': predict_data[predict_data.data_type == 'validation'].id.copy().values.ravel(),
+            'live': predict_data[predict_data.data_type == 'live'].id.copy().values.ravel(),
         }
+        clusters = get_competition_variables_from_df('1', train_data, predict_data, ids['valid'], ids['test'], ids['live'])
 
-        for f_num, feature in enumerate(features):
-            new_batch[feature] = sample[:, f_num]
-        new_df = pd.concat((new_df, pd.DataFrame.from_dict(new_batch)), axis=0)
-    return new_df
+        with Pool(pool_size) as pool:
+            times = pool.starmap(self.check_concordance, [(submission_data, clusters, ids) for _ in range(N_RUNS)])
 
-
-def check_concordance(submission, clusters, ids):
-    t0 = time.time()
-    ids_valid, ids_test, ids_live = ids['valid'], ids['test'], ids['live']
-    p1, p2, p3 = get_sorted_split(submission, ids_valid, ids_test, ids_live)
-    c1, c2, c3 = clusters['cluster_1'], clusters['cluster_2'], clusters['cluster_3']
-    has_concordance(p1, p2, p3, c1, c2, c3)
-    t1 = time.time()
-    return (t1 - t0) * 1000
-
-
-def run_benchmark():
-    # try to use half the available cores to avoid shaky medians per run caused by cpu usage from other processes
-    pool_size = os.cpu_count() or 1
-    if pool_size > 1:
-        pool_size = pool_size//2
-
-    source_train_data, source_predict_data, source_submission = load_data()
-    train_data, predict_data, submission_data = \
-        gen_more_data(source_train_data, source_predict_data, source_submission)
-
-    ids = {
-        'test': predict_data[predict_data.data_type == 'test'].id.copy().values.ravel(),
-        'valid': predict_data[predict_data.data_type == 'validation'].id.copy().values.ravel(),
-        'live': predict_data[predict_data.data_type == 'live'].id.copy().values.ravel(),
-    }
-    clusters = get_competition_variables_from_df('1', train_data, predict_data, ids['valid'], ids['test'], ids['live'])
-
-    with Pool(pool_size) as pool:
-        times = pool.starmap(check_concordance, [(submission_data, clusters, ids) for _ in range(N_RUNS)])
-
-    print('ran method %s times' % len(times))
-    print('median: %.2fms' % statistics.median(times))
-    print('mean: %.2fms' % statistics.mean(times))
-    print('stdev: %.2f' % statistics.stdev(times))
+        self.log('benchmark finished in %.2fs' % (sum(times)/1000))
+        self.log('[per iteration] %s' % self.format_stats(times, unit='ms'))
 
 
 if __name__ == '__main__':
-    run_benchmark()
+    benchmark = BenchmarkConcordance(n_runs=N_RUNS)
+    benchmark.start('benchmarking %s submissions with %s examples each' % (
+        N_RUNS, N_SAMPLES
+    ))

--- a/benchmark_originality.py
+++ b/benchmark_originality.py
@@ -1,4 +1,5 @@
 import time
+import numpy as np
 
 import randomstate as rnd
 
@@ -12,9 +13,9 @@ N_OTHER_SUBMISSIONS = 1000
 
 class OriginalityBenchmark(Benchmark):
     @staticmethod
-    def gen_submission(predictions=N_EXAMPLES, users=N_OTHER_SUBMISSIONS):
+    def gen_submission(predictions=N_EXAMPLES, users=N_OTHER_SUBMISSIONS) -> np.ndarray:
         # numpy's RandomSeed don't play well with multiprocessing; randomstate is a drop-in replacement
-        return rnd.normal(loc=0.5, scale=0.1, size=(predictions, users))
+        return np.array(rnd.normal(loc=0.5, scale=0.1, size=(predictions, users)))
 
     @staticmethod
     def check_original(new_submission, other_submissions):


### PR DESCRIPTION
Fix for #18.

- Don't run concordance benchmark in parallel because of 1) less cpu usage interference, and 2) it's not run in parallel in production,
- Using numpy arrays for concordance checks,
- Abstracted away some benchmark code in a base class.