### PR TITLE
migrate to v1.1 style target_number

### DIFF
--- a/submission_criteria/common.py
+++ b/submission_criteria/common.py
@@ -13,10 +13,6 @@ import botocore
 from sklearn.metrics import log_loss
 from submission_criteria import tournament_common as tc
 
-TARGETS = [
-    "sentinel", "target_bernie", "target_elizabeth", "target_jordan",
-    "target_ken", "target_charles"
-]
 S3_BUCKET = os.environ.get("S3_UPLOAD_BUCKET", "numerai-production-uploads")
 S3_ACCESS_KEY = os.environ.get("S3_ACCESS_KEY")
 S3_SECRET_KEY = os.environ.get("S3_SECRET_KEY")
@@ -119,9 +115,9 @@ def update_loglosses(submission_id):
         test_data["id"].as_matrix())].copy()
     submission_test_data.sort_values("id", inplace=True)
     validation_logloss = log_loss(
-        validation_data[TARGETS[tournament]].as_matrix(),
+        validation_data[f"target_{tournament}"].as_matrix(),
         submission_validation_data["probability"].as_matrix())
-    test_logloss = log_loss(test_data[TARGETS[tournament]].as_matrix(),
+    test_logloss = log_loss(test_data[f"target_{tournament}"].as_matrix(),
                             submission_test_data["probability"].as_matrix())
 
     # Insert values into Postgres

--- a/submission_criteria/database_manager.py
+++ b/submission_criteria/database_manager.py
@@ -84,7 +84,7 @@ class DatabaseManager():
                 submission_era_data > 0), "There must be data for every era"
             era_data = era_data.sort_values(["id"])
             submission_era_data = submission_era_data.sort_values(["id"])
-            logloss = log_loss(era_data[common.TARGETS[tournament]].values,
+            logloss = log_loss(era_data[f"target_{tournament}"].values,
                                submission_era_data.probability.values)
             if logloss < BENCHMARK:
                 better_than_random_era_count += 1


### PR DESCRIPTION
- targets are now target_number instead of target_name v1.1
- also remove hardcoded tournaments
- should be deployed for round 138

future:
- need a better way to handle version changes without a timed deploy