### PR TITLE
don't use target numbers for consistency since that measures against …

### DIFF
--- a/submission_criteria/common.py
+++ b/submission_criteria/common.py
@@ -21,6 +21,11 @@ s3 = boto3.resource(
 S3_INPUT_DATA_BUCKET = "numerai-tournament-data"
 INPUT_DATA_PATH = '/tmp/numerai-input-data'
 
+TARGETS = [
+    "sentinel", "target_bernie", "target_elizabeth", "target_jordan",
+    "target_ken", "target_charles", "target_frank", "target_hillary"
+]
+
 
 def get_secret(key):
     """Return a secret from S3."""

--- a/submission_criteria/database_manager.py
+++ b/submission_criteria/database_manager.py
@@ -84,7 +84,7 @@ class DatabaseManager():
                 submission_era_data > 0), "There must be data for every era"
             era_data = era_data.sort_values(["id"])
             submission_era_data = submission_era_data.sort_values(["id"])
-            logloss = log_loss(era_data[f"target_{tournament}"].values,
+            logloss = log_loss(era_data[common.TARGETS[tournament]].values,
                                submission_era_data.probability.values)
             if logloss < BENCHMARK:
                 better_than_random_era_count += 1


### PR DESCRIPTION
…generated data with names

- validation logloss is currently calculated against the tournament data inside the generated zip, which uses target_names instead of target_numbers. 

- test logloss is calculated against target_names (which is fine)